### PR TITLE
Fixed Reflection issue with Custom Builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ cache:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - travis_retry composer self-update
+  - composer show -D
 
 install:
   - if [[ $SETUP = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ cache:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - travis_retry composer self-update
-  - composer show -D
 
 install:
   - if [[ $SETUP = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
   - if [[ $SETUP = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
+  - composer show -D
 
 script: vendor/bin/phpunit

--- a/src/Concerns/ForwardsParentCalls.php
+++ b/src/Concerns/ForwardsParentCalls.php
@@ -67,15 +67,24 @@ trait ForwardsParentCalls
      */
     public function assignAcquiredProperties($parent)
     {
-        foreach ((new ReflectionClass($parent))->getProperties() as $property) {
+        $self = new ReflectionClass($this);
 
-            if($property->isStatic()) {
+        foreach ((new ReflectionClass($parent))->getProperties() as $parentProperty) {
+
+            if(!$self->hasProperty($parentProperty->getName())) {
                 continue;
             }
 
-            $property->setAccessible(true);
+            $selfProperty = $self->getProperty($parentProperty->getName());
 
-            $property->setValue($parent, $property->getValue($this));
+            if($parentProperty->isStatic()) {
+                continue;
+            }
+
+            $parentProperty->setAccessible(true);
+            $selfProperty->setAccessible(true);
+
+            $parentProperty->setValue($parent, $selfProperty->getValue($this));
 
         }
 

--- a/tests/DatabaseEloquentRelationJoinTest.php
+++ b/tests/DatabaseEloquentRelationJoinTest.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Reedware\LaravelRelationJoins\LaravelRelationJoinServiceProvider;
 
 class DatabaseEloquentRelationJoinTest extends TestCase

--- a/tests/DatabaseEloquentRelationJoinTest.php
+++ b/tests/DatabaseEloquentRelationJoinTest.php
@@ -787,6 +787,13 @@ class DatabaseEloquentRelationJoinTest extends TestCase
 
         $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or ("supplier"."has_international_restrictions" = ? and "supplier"."country" != ?))', $builder->toSql());
     }
+
+    public function testReflectionUsingCustomBuilder()
+    {
+        $builder = (new EloquentUserModelWithCustomBuilderStub)->newQuery()->joinRelation('roles');
+
+        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+    }
 }
 
 class EloquentRelationJoinModelStub extends Model
@@ -1157,4 +1164,32 @@ class EloquentSoftDeletingUserRolePivotStub extends EloquentRelationJoinPivotStu
     use SoftDeletes;
 
     protected $table = 'role_user';
+}
+
+class EloquentUserModelWithCustomBuilderStub extends EloquentUserModelStub
+{
+    /**
+     * Create a new Eloquent query builder for the model.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function newEloquentBuilder($query)
+    {
+        return new CustomBuilder($query);
+    }
+}
+
+class CustomBuilder extends EloquentBuilder
+{
+    /**
+     * The methods that should be returned from query builder.
+     *
+     * @var array
+     */
+    protected $passthru = [
+        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'sum', 'getConnection',
+        'myCustomOverrideforTesting'
+    ];
 }


### PR DESCRIPTION
If a developer was using their own custom builder, and override any of the properties from the Eloquent Builder, relation joins would cause a reflection exception to be thrown.