### PR TITLE
Add support for Custom Builders

### DIFF
--- a/tests/DatabaseEloquentRelationJoinTest.php
+++ b/tests/DatabaseEloquentRelationJoinTest.php
@@ -81,11 +81,45 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         return version_compare($this->version, $version) >= 0;
     }
 
+    public function testCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery();
+
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+
+        $builder = (new EloquentPostModelStub)->newQuery();
+
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+
+        $builder = (new EloquentUserModelStub)->useCustomBuilder(false)->newQuery();
+
+        $this->assertEquals(EloquentBuilder::class, get_class($builder));
+
+        $builder = (new EloquentPostModelStub)->newQuery();
+
+        $this->assertEquals(EloquentBuilder::class, get_class($builder));
+    }
+
+    public function testCustomBuilderResetsAfterTest()
+    {
+        $builder = (new EloquentUserModelStub)->newQuery();
+
+        $this->assertEquals(EloquentBuilder::class, get_class($builder));
+    }
+
     public function testSimpleHasOneRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('phone');
 
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+    }
+
+    public function testSimpleHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('phone');
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleHasOneInverseRelationJoin()
@@ -95,11 +129,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id"', $builder->toSql());
     }
 
+    public function testSimpleHasOneInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPhoneModelStub)->useCustomBuilder()->newQuery()->joinRelation('user');
+
+        $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleHasManyRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->joinRelation('comments');
 
         $this->assertEquals('select * from "posts" inner join "comments" on "comments"."post_id" = "posts"."id"', $builder->toSql());
+    }
+
+    public function testSimpleHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('comments');
+
+        $this->assertEquals('select * from "posts" inner join "comments" on "comments"."post_id" = "posts"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleHasManyInverseRelationJoin()
@@ -109,11 +159,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "comments" inner join "posts" on "posts"."id" = "comments"."post_id"', $builder->toSql());
     }
 
+    public function testSimpleHasManyInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCommentModelStub)->useCustomBuilder()->newQuery()->joinRelation('post');
+
+        $this->assertEquals('select * from "comments" inner join "posts" on "posts"."id" = "comments"."post_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleBelongsToManyRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('roles');
 
         $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+    }
+
+    public function testSimpleBelongsToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('roles');
+
+        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleBelongsToManyInverseRelationJoin()
@@ -123,9 +189,17 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "roles" inner join "role_user" on "role_user"."role_id" = "roles"."id" inner join "users" on "users"."id" = "role_user"."user_id"', $builder->toSql());
     }
 
+    public function testSimpleBelongsToManyInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentRoleModelStub)->useCustomBuilder()->newQuery()->joinRelation('users');
+
+        $this->assertEquals('select * from "roles" inner join "role_user" on "role_user"."role_id" = "roles"."id" inner join "users" on "users"."id" = "role_user"."user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleHasOneThroughRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -134,15 +208,39 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "suppliers" inner join "users" on "users"."supplier_id" = "suppliers"."id" inner join "history" on "history"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testSimpleHasOneThroughRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentSupplierModelStub)->useCustomBuilder()->newQuery()->joinRelation('userHistory');
+
+        $this->assertEquals('select * from "suppliers" inner join "users" on "users"."supplier_id" = "suppliers"."id" inner join "history" on "history"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleHasOneThroughInverseRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
         $builder = (new EloquentUserHistoryModelStub)->newQuery()->joinRelation('user.supplier');
 
         $this->assertEquals('select * from "history" inner join "users" on "users"."id" = "history"."user_id" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id"', $builder->toSql());
+    }
+
+    public function testSimpleHasOneThroughInverseRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentUserHistoryModelStub)->useCustomBuilder()->newQuery()->joinRelation('user.supplier');
+
+        $this->assertEquals('select * from "history" inner join "users" on "users"."id" = "history"."user_id" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleHasManyThroughRelationJoin()
@@ -152,11 +250,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testSimpleHasManyThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts');
+
+        $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleHasManyThroughInverseRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->joinRelation('user.country');
 
         $this->assertEquals('select * from "posts" inner join "users" on "users"."id" = "posts"."user_id" inner join "countries" on "countries"."id" = "users"."country_id"', $builder->toSql());
+    }
+
+    public function testSimpleHasManyThroughInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('user.country');
+
+        $this->assertEquals('select * from "posts" inner join "users" on "users"."id" = "posts"."user_id" inner join "countries" on "countries"."id" = "users"."country_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleMorphOneRelationJoin()
@@ -167,12 +281,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testSimpleMorphOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('image');
+
+        $this->assertEquals('select * from "posts" inner join "images" on "images"."imageable_id" = "posts"."id" and "images"."imageable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleMorphManyRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->joinRelation('polymorphicComments');
 
         $this->assertEquals('select * from "posts" inner join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testSimpleMorphManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('polymorphicComments');
+
+        $this->assertEquals('select * from "posts" inner join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testSimpleMorphToManyRelationJoin()
@@ -183,6 +315,15 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testSimpleMorphToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('tags');
+
+        $this->assertEquals('select * from "posts" inner join "taggables" on "taggables"."taggable_id" = "posts"."id" and "taggables"."taggable_type" = ? inner join "tags" on "tags"."id" = "taggables"."tag_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testSimpleMorphedByManyRelationJoin()
     {
         $builder = (new EloquentTagModelStub)->newQuery()->joinRelation('posts');
@@ -191,11 +332,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testSimpleMorphedByManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentTagModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts');
+
+        $this->assertEquals('select * from "tags" inner join "taggables" on "taggables"."tag_id" = "tags"."id" and "taggables"."taggable_type" = ? inner join "posts" on "posts"."id" = "taggables"."taggable_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMorphToRelationJoinThrowsException()
     {
         $this->expectException(RuntimeException::class);
 
         $builder = (new EloquentImageModelStub)->newQuery()->joinRelation('imageable');
+    }
+
+    public function testMorphToRelationJoinThrowsExceptionWithCustomBuilder()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = (new EloquentImageModelStub)->useCustomBuilder()->newQuery()->joinRelation('imageable');
     }
 
     public function testMorphOneAsHasOneRelationJoin()
@@ -206,12 +363,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testMorphOneAsHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('postImage');
+
+        $this->assertEquals('select * from "posts" inner join "images" on "images"."imageable_id" = "posts"."id" and "imageable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMorphToAsBelongsToRelationJoin()
     {
         $builder = (new EloquentImageModelStub)->newQuery()->joinRelation('postImageable');
 
         $this->assertEquals('select * from "images" inner join "posts" on "posts"."id" = "images"."imageable_id" and "imageable_type" = ?', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testMorphToAsBelongsToRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentImageModelStub)->useCustomBuilder()->newQuery()->joinRelation('postImageable');
+
+        $this->assertEquals('select * from "images" inner join "posts" on "posts"."id" = "images"."imageable_id" and "imageable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testMorphManyAsHasManyRelationJoin()
@@ -222,12 +397,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentVideoModelStub::class], $builder->getBindings());
     }
 
+    public function testMorphManyAsHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentVideoModelStub)->useCustomBuilder()->newQuery()->joinRelation('videoComments');
+
+        $this->assertEquals('select * from "videos" inner join "comments" on "comments"."commentable_id" = "videos"."id" and "commentable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentVideoModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMorphToManyAsBelongsToManyRelationJoin()
     {
         $builder = (new EloquentVideoModelStub)->newQuery()->joinRelation('videoTags');
 
         $this->assertEquals('select * from "videos" inner join "taggables" on "taggables"."taggable_id" = "videos"."id" inner join "tags" on "tags"."id" = "taggables"."tag_id" and "taggables"."taggable_type" = ?', $builder->toSql());
         $this->assertEquals([0 => EloquentVideoModelStub::class], $builder->getBindings());
+    }
+
+    public function testMorphToManyAsBelongsToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentVideoModelStub)->useCustomBuilder()->newQuery()->joinRelation('videoTags');
+
+        $this->assertEquals('select * from "videos" inner join "taggables" on "taggables"."taggable_id" = "videos"."id" inner join "tags" on "tags"."id" = "taggables"."tag_id" and "taggables"."taggable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentVideoModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasOneUsingAliasRelationJoin()
@@ -237,11 +430,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" as "telephones" on "telephones"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testHasOneUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('phone as telephones');
+
+        $this->assertEquals('select * from "users" inner join "phones" as "telephones" on "telephones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneInverseUsingAliasRelationJoin()
     {
         $builder = (new EloquentPhoneModelStub)->newQuery()->joinRelation('user as contacts');
 
         $this->assertEquals('select * from "phones" inner join "users" as "contacts" on "contacts"."id" = "phones"."user_id"', $builder->toSql());
+    }
+
+    public function testHasOneInverseUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPhoneModelStub)->useCustomBuilder()->newQuery()->joinRelation('user as contacts');
+
+        $this->assertEquals('select * from "phones" inner join "users" as "contacts" on "contacts"."id" = "phones"."user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManyUsingAliasRelationJoin()
@@ -251,11 +460,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "posts" inner join "comments" as "feedback" on "feedback"."post_id" = "posts"."id"', $builder->toSql());
     }
 
+    public function testHasManyUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('comments as feedback');
+
+        $this->assertEquals('select * from "posts" inner join "comments" as "feedback" on "feedback"."post_id" = "posts"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManyInverseUsingAliasRelationJoin()
     {
         $builder = (new EloquentCommentModelStub)->newQuery()->joinRelation('post as article');
 
         $this->assertEquals('select * from "comments" inner join "posts" as "article" on "article"."id" = "comments"."post_id"', $builder->toSql());
+    }
+
+    public function testHasManyInverseUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCommentModelStub)->useCustomBuilder()->newQuery()->joinRelation('post as article');
+
+        $this->assertEquals('select * from "comments" inner join "posts" as "article" on "article"."id" = "comments"."post_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testBelongsToManyUsingFarAliasRelationJoin()
@@ -265,11 +490,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" as "positions" on "positions"."id" = "role_user"."role_id"', $builder->toSql());
     }
 
+    public function testBelongsToManyUsingFarAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('roles as positions');
+
+        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" as "positions" on "positions"."id" = "role_user"."role_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testBelongsToManyUsingPivotAliasRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('roles as users_roles,roles');
 
         $this->assertEquals('select * from "users" inner join "role_user" as "users_roles" on "users_roles"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "users_roles"."role_id"', $builder->toSql());
+    }
+
+    public function testBelongsToManyUsingPivotAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('roles as users_roles,roles');
+
+        $this->assertEquals('select * from "users" inner join "role_user" as "users_roles" on "users_roles"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "users_roles"."role_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testBelongsToManyUsingPivotAndFarAliasRelationJoin()
@@ -279,9 +520,17 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "role_user" as "position_user" on "position_user"."user_id" = "users"."id" inner join "roles" as "positions" on "positions"."id" = "position_user"."role_id"', $builder->toSql());
     }
 
+    public function testBelongsToManyUsingPivotAndFarAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('roles as position_user,positions');
+
+        $this->assertEquals('select * from "users" inner join "role_user" as "position_user" on "position_user"."user_id" = "users"."id" inner join "roles" as "positions" on "positions"."id" = "position_user"."role_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughUsingFarAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -290,9 +539,21 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "suppliers" inner join "users" on "users"."supplier_id" = "suppliers"."id" inner join "history" as "revisions" on "revisions"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testHasOneThroughUsingFarAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentSupplierModelStub)->useCustomBuilder()->newQuery()->joinRelation('userHistory as revisions');
+
+        $this->assertEquals('select * from "suppliers" inner join "users" on "users"."supplier_id" = "suppliers"."id" inner join "history" as "revisions" on "revisions"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughUsingThroughAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -301,9 +562,21 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "suppliers" inner join "users" as "workers" on "workers"."supplier_id" = "suppliers"."id" inner join "history" on "history"."user_id" = "workers"."id"', $builder->toSql());
     }
 
+    public function testHasOneThroughUsingThroughAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentSupplierModelStub)->useCustomBuilder()->newQuery()->joinRelation('userHistory as workers,history');
+
+        $this->assertEquals('select * from "suppliers" inner join "users" as "workers" on "workers"."supplier_id" = "suppliers"."id" inner join "history" on "history"."user_id" = "workers"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughUsingThroughAndFarAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -312,9 +585,21 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "suppliers" inner join "users" as "workers" on "workers"."supplier_id" = "suppliers"."id" inner join "history" as "revisions" on "revisions"."user_id" = "workers"."id"', $builder->toSql());
     }
 
+    public function testHasOneThroughUsingThroughAndFarAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentSupplierModelStub)->useCustomBuilder()->newQuery()->joinRelation('userHistory as workers,revisions');
+
+        $this->assertEquals('select * from "suppliers" inner join "users" as "workers" on "workers"."supplier_id" = "suppliers"."id" inner join "history" as "revisions" on "revisions"."user_id" = "workers"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughInverseUsingFarAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -323,9 +608,21 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "history" inner join "users" on "users"."id" = "history"."user_id" inner join "suppliers" as "providers" on "providers"."id" = "users"."supplier_id"', $builder->toSql());
     }
 
+    public function testHasOneThroughInverseUsingFarAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentUserHistoryModelStub)->useCustomBuilder()->newQuery()->joinRelation('user.supplier as providers');
+
+        $this->assertEquals('select * from "history" inner join "users" on "users"."id" = "history"."user_id" inner join "suppliers" as "providers" on "providers"."id" = "users"."supplier_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughInverseUsingThroughAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -334,15 +631,39 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "history" inner join "users" as "workers" on "workers"."id" = "history"."user_id" inner join "suppliers" on "suppliers"."id" = "workers"."supplier_id"', $builder->toSql());
     }
 
+    public function testHasOneThroughInverseUsingThroughAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentUserHistoryModelStub)->useCustomBuilder()->newQuery()->joinRelation('user as workers.supplier');
+
+        $this->assertEquals('select * from "history" inner join "users" as "workers" on "workers"."id" = "history"."user_id" inner join "suppliers" on "suppliers"."id" = "workers"."supplier_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasOneThroughInverseUsingThroughAndFarAliasRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
         $builder = (new EloquentUserHistoryModelStub)->newQuery()->joinRelation('user as workers.supplier as providers');
 
         $this->assertEquals('select * from "history" inner join "users" as "workers" on "workers"."id" = "history"."user_id" inner join "suppliers" as "providers" on "providers"."id" = "workers"."supplier_id"', $builder->toSql());
+    }
+
+    public function testHasOneThroughInverseUsingThroughAndFarAliasRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentUserHistoryModelStub)->useCustomBuilder()->newQuery()->joinRelation('user as workers.supplier as providers');
+
+        $this->assertEquals('select * from "history" inner join "users" as "workers" on "workers"."id" = "history"."user_id" inner join "suppliers" as "providers" on "providers"."id" = "workers"."supplier_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManyThroughUsingFarAliasRelationJoin()
@@ -352,6 +673,14 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testHasManyThroughUsingFarAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts as articles');
+
+        $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManyThroughUsingThroughAliasRelationJoin()
     {
         $builder = (new EloquentCountryModelStub)->newQuery()->joinRelation('posts as citizens,posts');
@@ -359,11 +688,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "citizens"."id"', $builder->toSql());
     }
 
+    public function testHasManyThroughUsingThroughAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts as citizens,posts');
+
+        $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "citizens"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManyThroughUsingThroughAndFarAliasRelationJoin()
     {
         $builder = (new EloquentCountryModelStub)->newQuery()->joinRelation('posts as citizens,articles');
 
         $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "citizens"."id"', $builder->toSql());
+    }
+
+    public function testHasManyThroughUsingThroughAndFarAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts as citizens,articles');
+
+        $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "citizens"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testMorphOneUsingAliasRelationJoin()
@@ -374,12 +719,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testMorphOneUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('image');
+
+        $this->assertEquals('select * from "posts" inner join "images" on "images"."imageable_id" = "posts"."id" and "images"."imageable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMorphManyUsingAliasRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->joinRelation('polymorphicComments');
 
         $this->assertEquals('select * from "posts" inner join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testMorphManyUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('polymorphicComments');
+
+        $this->assertEquals('select * from "posts" inner join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testMorphToManyUsingAliasRelationJoin()
@@ -390,12 +753,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testMorphToManyUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('tags');
+
+        $this->assertEquals('select * from "posts" inner join "taggables" on "taggables"."taggable_id" = "posts"."id" and "taggables"."taggable_type" = ? inner join "tags" on "tags"."id" = "taggables"."tag_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMorphedByManyUsingAliasRelationJoin()
     {
         $builder = (new EloquentTagModelStub)->newQuery()->joinRelation('posts');
 
         $this->assertEquals('select * from "tags" inner join "taggables" on "taggables"."tag_id" = "tags"."id" and "taggables"."taggable_type" = ? inner join "posts" on "posts"."id" = "taggables"."taggable_id"', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testMorphedByManyUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentTagModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts');
+
+        $this->assertEquals('select * from "tags" inner join "taggables" on "taggables"."tag_id" = "tags"."id" and "taggables"."taggable_type" = ? inner join "posts" on "posts"."id" = "taggables"."taggable_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testParentSoftDeletesHasOneRelationJoin()
@@ -405,6 +786,14 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" where "users"."deleted_at" is null', $builder->toSql());
     }
 
+    public function testParentSoftDeletesHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('phone');
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" where "users"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentSoftDeletesHasOneWithTrashedRelationJoin()
     {
         $builder = (new EloquentSoftDeletingUserModelStub)->newQuery()->joinRelation('phone')->withTrashed();
@@ -412,11 +801,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testParentSoftDeletesHasOneWithTrashedRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('phone')->withTrashed();
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testChildSoftDeletesHasOneRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('softDeletingPhone');
 
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testChildSoftDeletesHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPhone');
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testChildSoftDeletesHasOneWithTrashedRelationJoin()
@@ -428,6 +833,16 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testChildSoftDeletesHasOneWithTrashedRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPhone', function ($join) {
+            $join->withTrashed();
+        });
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentAndChildSoftDeletesHasOneRelationJoin()
     {
         $builder = (new EloquentSoftDeletingUserModelStub)->newQuery()->joinRelation('softDeletingPhone');
@@ -435,11 +850,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null where "users"."deleted_at" is null', $builder->toSql());
     }
 
+    public function testParentAndChildSoftDeletesHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPhone');
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null where "users"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentAndChildSoftDeletesHasOneWithTrashedParentRelationJoin()
     {
         $builder = (new EloquentSoftDeletingUserModelStub)->newQuery()->joinRelation('softDeletingPhone')->withTrashed();
 
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testParentAndChildSoftDeletesHasOneWithTrashedParentRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPhone')->withTrashed();
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" and "phones"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testParentAndChildSoftDeletesHasOneWithTrashedChildRelationJoin()
@@ -451,6 +882,16 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" where "users"."deleted_at" is null', $builder->toSql());
     }
 
+    public function testParentAndChildSoftDeletesHasOneWithTrashedChildRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPhone', function ($join) {
+            $join->withTrashed();
+        });
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id" where "users"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentAndChildSoftDeletesHasOneWithTrashedRelationJoin()
     {
         $builder = (new EloquentSoftDeletingUserModelStub)->newQuery()->withTrashed()->joinRelation('softDeletingPhone', function ($join) {
@@ -460,11 +901,29 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testParentAndChildSoftDeletesHasOneWithTrashedRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->withTrashed()->joinRelation('softDeletingPhone', function ($join) {
+            $join->withTrashed();
+        });
+
+        $this->assertEquals('select * from "users" inner join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentSoftSimpleHasOneInverseRelationJoin()
     {
         $builder = (new EloquentPhoneModelStub)->newQuery()->joinRelation('softDeletingUser');
 
         $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id" and "users"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testParentSoftSimpleHasOneInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPhoneModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingUser');
+
+        $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id" and "users"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testChildSoftSimpleHasOneInverseRelationJoin()
@@ -474,11 +933,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id" where "phones"."deleted_at" is null', $builder->toSql());
     }
 
+    public function testChildSoftSimpleHasOneInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingPhoneModelStub)->useCustomBuilder()->newQuery()->joinRelation('user');
+
+        $this->assertEquals('select * from "phones" inner join "users" on "users"."id" = "phones"."user_id" where "phones"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testParentSoftDeletesHasManyThroughRelationJoin()
     {
         $builder = (new EloquentSoftDeletingCountryModelStub)->newQuery()->joinRelation('posts');
 
         $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id" where "countries"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testParentSoftDeletesHasManyThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts');
+
+        $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id" where "countries"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testThroughSoftDeletesHasManyThroughRelationJoin()
@@ -492,11 +967,32 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         }
     }
 
+    public function testThroughSoftDeletesHasManyThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('postsThroughSoftDeletingUser');
+
+        if($this->isVersionAfter('7.10.0')) {
+            $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" and "users"."deleted_at" is null inner join "posts" on "posts"."user_id" = "users"."id"', $builder->toSql());
+        } else {
+            $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" and "users"."deleted_at" is null inner join "posts" on "posts"."user_id" = "users"."id" and "users"."deleted_at" is null', $builder->toSql());
+        }
+
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testChildSoftDeletesHasManyThroughRelationJoin()
     {
         $builder = (new EloquentCountryModelStub)->newQuery()->joinRelation('softDeletingPosts');
 
         $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testChildSoftDeletesHasManyThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingPosts');
+
+        $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testParentSoftDeletesBelongsToManyRelationJoin()
@@ -506,11 +1002,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id" where "users"."deleted_at" is null', $builder->toSql());
     }
 
+    public function testParentSoftDeletesBelongsToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('roles');
+
+        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id" where "users"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testChildSoftDeletesBelongsToManyRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('softDeletingRoles');
 
         $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id" and "roles"."deleted_at" is null', $builder->toSql());
+    }
+
+    public function testChildSoftDeletesBelongsToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('softDeletingRoles');
+
+        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id" and "roles"."deleted_at" is null', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testBelongsToSelfRelationJoin()
@@ -520,11 +1032,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."id" = "users"."manager_id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
     }
 
+    public function testBelongsToSelfRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('manager');
+
+        $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."id" = "users"."manager_id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testBelongsToSelfUsingAliasRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('manager as managers');
 
         $this->assertEquals('select * from "users" inner join "users" as "managers" on "managers"."id" = "users"."manager_id"', $builder->toSql());
+    }
+
+    public function testBelongsToSelfUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('manager as managers');
+
+        $this->assertEquals('select * from "users" inner join "users" as "managers" on "managers"."id" = "users"."manager_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManySelfRelationJoin()
@@ -534,11 +1062,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."manager_id" = "users"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
     }
 
+    public function testHasManySelfRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employees');
+
+        $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."manager_id" = "users"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManySelfUsingAliasRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('employees as employees');
 
         $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id"', $builder->toSql());
+    }
+
+    public function testHasManySelfUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employees as employees');
+
+        $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManyThroughSelfRelationJoin()
@@ -548,11 +1092,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."manager_id" = "users"."id" inner join "posts" on "posts"."user_id" = "self_alias_hash"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
     }
 
+    public function testHasManyThroughSelfRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employeePosts');
+
+        $this->assertEquals('select * from "users" inner join "users" as "self_alias_hash" on "self_alias_hash"."manager_id" = "users"."id" inner join "posts" on "posts"."user_id" = "self_alias_hash"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManyThroughSelfUsingAliasRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('employeePosts as employees,posts');
 
         $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id" inner join "posts" on "posts"."user_id" = "employees"."id"', $builder->toSql());
+    }
+
+    public function testHasManyThroughSelfUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employeePosts as employees,posts');
+
+        $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id" inner join "posts" on "posts"."user_id" = "employees"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManyThroughSoftDeletingSelfUsingAliasRelationJoin()
@@ -566,11 +1126,32 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         }
     }
 
+    public function testHasManyThroughSoftDeletingSelfUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentSoftDeletingUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employeePosts as employees,posts');
+
+        if($this->isVersionAfter('7.10.0')) {
+            $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id" and "employees"."deleted_at" is null inner join "posts" on "posts"."user_id" = "employees"."id" where "users"."deleted_at" is null', $builder->toSql());
+        } else {
+            $this->assertEquals('select * from "users" inner join "users" as "employees" on "employees"."manager_id" = "users"."id" and "employees"."deleted_at" is null inner join "posts" on "posts"."user_id" = "employees"."id" and "users"."deleted_at" is null where "users"."deleted_at" is null', $builder->toSql());
+        }
+
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testHasManySelfThroughRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('departmentEmployees');
 
         $this->assertEquals('select * from "users" inner join "departments" on "departments"."supervisor_id" = "users"."id" inner join "users" as "self_alias_hash" on "self_alias_hash"."department_id" = "departments"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+    }
+
+    public function testHasManySelfThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('departmentEmployees');
+
+        $this->assertEquals('select * from "users" inner join "departments" on "departments"."supervisor_id" = "users"."id" inner join "users" as "self_alias_hash" on "self_alias_hash"."department_id" = "departments"."id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManySelfThroughSoftDeletingUsingAliasRelationJoin()
@@ -584,6 +1165,19 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         }
     }
 
+    public function testHasManySelfThroughSoftDeletingUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('employeesThroughSoftDeletingDepartment as employees');
+
+        if($this->isVersionAfter('7.10.0')) {
+            $this->assertEquals('select * from "users" inner join "departments" on "departments"."supervisor_id" = "users"."id" and "departments"."deleted_at" is null inner join "users" as "employees" on "employees"."department_id" = "departments"."id"', $builder->toSql());
+        } else {
+            $this->assertEquals('select * from "users" inner join "departments" on "departments"."supervisor_id" = "users"."id" and "departments"."deleted_at" is null inner join "users" as "employees" on "employees"."department_id" = "departments"."id" and "departments"."deleted_at" is null', $builder->toSql());
+        }
+
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testBelongsToManySelfRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('messagedUsers');
@@ -591,11 +1185,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "messages" on "messages"."from_user_id" = "users"."id" inner join "users" as "self_alias_hash" on "self_alias_hash"."id" = "messages"."to_user_id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
     }
 
+    public function testBelongsToManySelfRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('messagedUsers');
+
+        $this->assertEquals('select * from "users" inner join "messages" on "messages"."from_user_id" = "users"."id" inner join "users" as "self_alias_hash" on "self_alias_hash"."id" = "messages"."to_user_id"', preg_replace('/\b(laravel_reserved_\d)(\b|$)/i', 'self_alias_hash', $builder->toSql()));
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testBelongsToManySelfUsingAliasRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('messagedUsers as recipients');
 
         $this->assertEquals('select * from "users" inner join "messages" on "messages"."from_user_id" = "users"."id" inner join "users" as "recipients" on "recipients"."id" = "messages"."to_user_id"', $builder->toSql());
+    }
+
+    public function testBelongsToManySelfUsingAliasRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('messagedUsers as recipients');
+
+        $this->assertEquals('select * from "users" inner join "messages" on "messages"."from_user_id" = "users"."id" inner join "users" as "recipients" on "recipients"."id" = "messages"."to_user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testThroughJoinForHasManyRelationJoin()
@@ -610,11 +1220,32 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testThroughJoinForHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function ($join) {
+            $join->where('posts.is_active', '=', 1);
+        })->joinThroughRelation('posts.comments', function ($join) {
+            $join->whereColumn('comments.created_by_id', '=', 'users.id');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."is_active" = ? inner join "comments" on "comments"."post_id" = "posts"."id" and "comments"."created_by_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftHasOneRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->leftJoinRelation('phone');
 
         $this->assertEquals('select * from "users" left join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+    }
+
+    public function testLeftHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('phone');
+
+        $this->assertEquals('select * from "users" left join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftHasOneInverseRelationJoin()
@@ -624,11 +1255,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "phones" left join "users" on "users"."id" = "phones"."user_id"', $builder->toSql());
     }
 
+    public function testLeftHasOneInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPhoneModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('user');
+
+        $this->assertEquals('select * from "phones" left join "users" on "users"."id" = "phones"."user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftHasManyRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->leftJoinRelation('comments');
 
         $this->assertEquals('select * from "posts" left join "comments" on "comments"."post_id" = "posts"."id"', $builder->toSql());
+    }
+
+    public function testLeftHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('comments');
+
+        $this->assertEquals('select * from "posts" left join "comments" on "comments"."post_id" = "posts"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftHasManyInverseRelationJoin()
@@ -638,11 +1285,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "comments" left join "posts" on "posts"."id" = "comments"."post_id"', $builder->toSql());
     }
 
+    public function testLeftHasManyInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCommentModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('post');
+
+        $this->assertEquals('select * from "comments" left join "posts" on "posts"."id" = "comments"."post_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftBelongsToManyRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->leftJoinRelation('roles');
 
         $this->assertEquals('select * from "users" left join "role_user" on "role_user"."user_id" = "users"."id" left join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+    }
+
+    public function testLeftBelongsToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('roles');
+
+        $this->assertEquals('select * from "users" left join "role_user" on "role_user"."user_id" = "users"."id" left join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftBelongsToManyInverseRelationJoin()
@@ -652,9 +1315,17 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "roles" left join "role_user" on "role_user"."role_id" = "roles"."id" left join "users" on "users"."id" = "role_user"."user_id"', $builder->toSql());
     }
 
+    public function testLeftBelongsToManyInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentRoleModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('users');
+
+        $this->assertEquals('select * from "roles" left join "role_user" on "role_user"."role_id" = "roles"."id" left join "users" on "users"."id" = "role_user"."user_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftHasOneThroughRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
@@ -663,15 +1334,39 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "suppliers" left join "users" on "users"."supplier_id" = "suppliers"."id" left join "history" on "history"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testLeftHasOneThroughRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentSupplierModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('userHistory');
+
+        $this->assertEquals('select * from "suppliers" left join "users" on "users"."supplier_id" = "suppliers"."id" left join "history" on "history"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftHasOneThroughInverseRelationJoin()
     {
-        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOnrThrough::class)) {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
             return;
         }
 
         $builder = (new EloquentUserHistoryModelStub)->newQuery()->leftJoinRelation('user.supplier');
 
         $this->assertEquals('select * from "history" left join "users" on "users"."id" = "history"."user_id" left join "suppliers" on "suppliers"."id" = "users"."supplier_id"', $builder->toSql());
+    }
+
+    public function testLeftHasOneThroughInverseRelationJoinWithCustomBuilder()
+    {
+        if(!class_exists(\Illuminate\Database\Eloquent\Relations\HasOneThrough::class)) {
+            return;
+        }
+
+        $builder = (new EloquentUserHistoryModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('user.supplier');
+
+        $this->assertEquals('select * from "history" left join "users" on "users"."id" = "history"."user_id" left join "suppliers" on "suppliers"."id" = "users"."supplier_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftHasManyThroughRelationJoin()
@@ -681,11 +1376,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "countries" left join "users" on "users"."country_id" = "countries"."id" left join "posts" on "posts"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testLeftHasManyThroughRelationJoinWithCustmBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('posts');
+
+        $this->assertEquals('select * from "countries" left join "users" on "users"."country_id" = "countries"."id" left join "posts" on "posts"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftHasManyThroughInverseRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->leftJoinRelation('user.country');
 
         $this->assertEquals('select * from "posts" left join "users" on "users"."id" = "posts"."user_id" left join "countries" on "countries"."id" = "users"."country_id"', $builder->toSql());
+    }
+
+    public function testLeftHasManyThroughInverseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('user.country');
+
+        $this->assertEquals('select * from "posts" left join "users" on "users"."id" = "posts"."user_id" left join "countries" on "countries"."id" = "users"."country_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftMorphOneRelationJoin()
@@ -696,12 +1407,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testLeftMorphOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('image');
+
+        $this->assertEquals('select * from "posts" left join "images" on "images"."imageable_id" = "posts"."id" and "images"."imageable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftMorphManyRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->leftJoinRelation('polymorphicComments');
 
         $this->assertEquals('select * from "posts" left join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testLeftMorphManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('polymorphicComments');
+
+        $this->assertEquals('select * from "posts" left join "comments" on "comments"."commentable_id" = "posts"."id" and "comments"."commentable_type" = ?', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftMorphToManyRelationJoin()
@@ -712,12 +1441,30 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
     }
 
+    public function testLeftMorphToManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('tags');
+
+        $this->assertEquals('select * from "posts" left join "taggables" on "taggables"."taggable_id" = "posts"."id" and "taggables"."taggable_type" = ? left join "tags" on "tags"."id" = "taggables"."tag_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testLeftMorphedByManyRelationJoin()
     {
         $builder = (new EloquentTagModelStub)->newQuery()->leftJoinRelation('posts');
 
         $this->assertEquals('select * from "tags" left join "taggables" on "taggables"."tag_id" = "tags"."id" and "taggables"."taggable_type" = ? left join "posts" on "posts"."id" = "taggables"."taggable_id"', $builder->toSql());
         $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+    }
+
+    public function testLeftMorphedByManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentTagModelStub)->useCustomBuilder()->newQuery()->leftJoinRelation('posts');
+
+        $this->assertEquals('select * from "tags" left join "taggables" on "taggables"."tag_id" = "tags"."id" and "taggables"."taggable_type" = ? left join "posts" on "posts"."id" = "taggables"."taggable_id"', $builder->toSql());
+        $this->assertEquals([0 => EloquentPostModelStub::class], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testRightHasOneRelationJoin()
@@ -727,11 +1474,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" right join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
     }
 
+    public function testRightHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->rightJoinRelation('phone');
+
+        $this->assertEquals('select * from "users" right join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testCrossHasOneRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->crossJoinRelation('phone');
 
         $this->assertEquals('select * from "users" cross join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+    }
+
+    public function testCrossHasOneRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->crossJoinRelation('phone');
+
+        $this->assertEquals('select * from "users" cross join "phones" on "phones"."user_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testLeftThroughJoinForHasManyRelationJoin()
@@ -746,6 +1509,19 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testLeftThroughJoinForHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function ($join) {
+            $join->where('posts.is_active', '=', 1);
+        })->leftJoinThroughRelation('posts.comments', function ($join) {
+            $join->whereColumn('comments.created_by_id', '=', 'users.id');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."is_active" = ? left join "comments" on "comments"."post_id" = "posts"."id" and "comments"."created_by_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testRightThroughJoinForHasManyRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('posts', function ($join) {
@@ -756,6 +1532,19 @@ class DatabaseEloquentRelationJoinTest extends TestCase
 
         $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."is_active" = ? right join "comments" on "comments"."post_id" = "posts"."id" and "comments"."created_by_id" = "users"."id"', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
+    public function testRightThroughJoinForHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function ($join) {
+            $join->where('posts.is_active', '=', 1);
+        })->rightJoinThroughRelation('posts.comments', function ($join) {
+            $join->whereColumn('comments.created_by_id', '=', 'users.id');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."is_active" = ? right join "comments" on "comments"."post_id" = "posts"."id" and "comments"."created_by_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testCrossThroughJoinForHasManyRelationJoin()
@@ -770,11 +1559,32 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testCrossThroughJoinForHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function ($join) {
+            $join->where('posts.is_active', '=', 1);
+        })->crossJoinThroughRelation('posts.comments', function ($join) {
+            $join->whereColumn('comments.created_by_id', '=', 'users.id');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and "posts"."is_active" = ? cross join "comments" on "comments"."post_id" = "posts"."id" and "comments"."created_by_id" = "users"."id"', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMultipleAliasesForBelongsToRelationJoin()
     {
         $builder = (new EloquentPostModelStub)->newQuery()->joinRelation('user as authors.country as nations');
 
         $this->assertEquals('select * from "posts" inner join "users" as "authors" on "authors"."id" = "posts"."user_id" inner join "countries" as "nations" on "nations"."id" = "authors"."country_id"', $builder->toSql());
+    }
+
+    public function testMultipleAliasesForBelongsToRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentPostModelStub)->useCustomBuilder()->newQuery()->joinRelation('user as authors.country as nations');
+
+        $this->assertEquals('select * from "posts" inner join "users" as "authors" on "authors"."id" = "posts"."user_id" inner join "countries" as "nations" on "nations"."id" = "authors"."country_id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testMultipleAliasesForHasManyRelationJoin()
@@ -784,11 +1594,27 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "posts" as "articles" on "articles"."user_id" = "users"."id" inner join "comments" as "reviews" on "reviews"."post_id" = "articles"."id"', $builder->toSql());
     }
 
+    public function testMultipleAliasesForHasManyRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts as articles.comments as reviews');
+
+        $this->assertEquals('select * from "users" inner join "posts" as "articles" on "articles"."user_id" = "users"."id" inner join "comments" as "reviews" on "reviews"."post_id" = "articles"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testMultipleAliasesForHasManyThroughRelationJoin()
     {
         $builder = (new EloquentCountryModelStub)->newQuery()->joinRelation('posts as citizens,articles.likes as feedback,favorites');
 
         $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "citizens"."id" inner join "comments" as "feedback" on "feedback"."post_id" = "articles"."id" inner join "likes" as "favorites" on "favorites"."comment_id" = "feedback"."id"', $builder->toSql());
+    }
+
+    public function testMultipleAliasesForHasManyThroughRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts as citizens,articles.likes as feedback,favorites');
+
+        $this->assertEquals('select * from "countries" inner join "users" as "citizens" on "citizens"."country_id" = "countries"."id" inner join "posts" as "articles" on "articles"."user_id" = "citizens"."id" inner join "comments" as "feedback" on "feedback"."post_id" = "articles"."id" inner join "likes" as "favorites" on "favorites"."comment_id" = "feedback"."id"', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testHasManyUsingLocalScopeRelationJoin()
@@ -801,6 +1627,17 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testHasManyUsingLocalScopeRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentCountryModelStub)->useCustomBuilder()->newQuery()->joinRelation('users', function ($join) {
+            $join->active();
+        });
+
+        $this->assertEquals('select * from "countries" inner join "users" on "users"."country_id" = "countries"."id" and "active" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
     public function testBelongsToWithNestedClauseRelationJoin()
     {
         $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('supplier', function($join) {
@@ -811,6 +1648,19 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         });
 
         $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or "supplier"."has_international_restrictions" = ?)', $builder->toSql());
+    }
+
+    public function testBelongsToWithNestedClauseRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('supplier', function($join) {
+            $join->where(function($join) {
+                $join->whereIn('supplier.state', ['AZ', 'CA', 'TX']);
+                $join->orWhere('supplier.has_international_restrictions', 1);
+            });
+        });
+
+        $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or "supplier"."has_international_restrictions" = ?)', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 
     public function testBelongsToWithRecursiveNestedClauseRelationJoin()
@@ -828,16 +1678,38 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or ("supplier"."has_international_restrictions" = ? and "supplier"."country" != ?))', $builder->toSql());
     }
 
-    public function testReflectionUsingCustomBuilder()
+    public function testBelongsToWithRecursiveNestedClauseRelationJoinWithCustomBuilder()
     {
-        $builder = (new EloquentUserModelWithCustomBuilderStub)->newQuery()->joinRelation('roles');
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('supplier', function($join) {
+            $join->where(function($join) {
+                $join->whereIn('supplier.state', ['AZ', 'CA', 'TX']);
+                $join->orWhere(function($join) {
+                    $join->where('supplier.has_international_restrictions', 1);
+                    $join->where('supplier.country', '!=', 'US');
+                });
+            });
+        });
 
-        $this->assertEquals('select * from "users" inner join "role_user" on "role_user"."user_id" = "users"."id" inner join "roles" on "roles"."id" = "role_user"."role_id"', $builder->toSql());
+        $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or ("supplier"."has_international_restrictions" = ? and "supplier"."country" != ?))', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));        
     }
 }
 
 class EloquentRelationJoinModelStub extends Model
 {
+    public static $useCustomBuilder = false;
+
+    public function useCustomBuilder($enabled = true)
+    {
+        static::$useCustomBuilder = $enabled;
+
+        return $this;
+    }
+
+    public function newEloquentBuilder($query)
+    {
+        return static::$useCustomBuilder ? new CustomBuilder($query) : new EloquentBuilder($query);
+    }
 }
 
 class EloquentRelationJoinPivotStub extends Pivot
@@ -1204,20 +2076,6 @@ class EloquentSoftDeletingUserRolePivotStub extends EloquentRelationJoinPivotStu
     use SoftDeletes;
 
     protected $table = 'role_user';
-}
-
-class EloquentUserModelWithCustomBuilderStub extends EloquentUserModelStub
-{
-    /**
-     * Create a new Eloquent query builder for the model.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder|static
-     */
-    public function newEloquentBuilder($query)
-    {
-        return new CustomBuilder($query);
-    }
 }
 
 class CustomBuilder extends EloquentBuilder


### PR DESCRIPTION
Custom Builders are technically already supported, but there isn't any testing coverage for them.

This PR adds in the tests for Custom Builders so that they can be officially supported moving forward.