### PR TITLE
Fix Existence Checks within Join Clauses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/database": "^5.5|^6.0|^7.0",
-        "illuminate/support": "^5.5|^6.0|^7.0"
+        "illuminate/database": "^5.5.43|^6.0|^7.0",
+        "illuminate/support": "^5.5.43|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.5|^8.0",
-        "illuminate/container": "^5.5|^6.0|^7.0"
+        "illuminate/container": "^5.5.43|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Concerns/JoinsRelationships.php
+++ b/src/Concerns/JoinsRelationships.php
@@ -138,6 +138,10 @@ trait JoinsRelationships
                 return $where;
             }
 
+            if($where['type'] == 'Exists' || $where['type'] == 'NotExists') {
+                return $where;
+            }
+
             $this->replaceWhereNestedQueryBuildersWithJoinBuilders($where['query']);
 
             $joinClause = new JoinClause($where['query'], 'inner', $where['query']->from);

--- a/tests/DatabaseEloquentRelationJoinTest.php
+++ b/tests/DatabaseEloquentRelationJoinTest.php
@@ -1709,7 +1709,45 @@ class DatabaseEloquentRelationJoinTest extends TestCase
         });
 
         $this->assertEquals('select * from "users" inner join "suppliers" on "suppliers"."id" = "users"."supplier_id" and ("supplier"."state" in (?, ?, ?) or ("supplier"."has_international_restrictions" = ? and "supplier"."country" != ?))', $builder->toSql());
-        $this->assertEquals(CustomBuilder::class, get_class($builder));        
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
+    public function testHasRelationWithinRelationJoin()
+    {
+        $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('posts', function($join) {
+            $join->has('comments');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and exists (select * from "comments" where "posts"."id" = "comments"."post_id")', $builder->toSql());
+    }
+
+    public function testHasRelationWithinRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function($join) {
+            $join->has('comments');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and exists (select * from "comments" where "posts"."id" = "comments"."post_id")', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
+    }
+
+    public function testDoesntHaveRelationWithinRelationJoin()
+    {
+        $builder = (new EloquentUserModelStub)->newQuery()->joinRelation('posts', function($join) {
+            $join->doesntHave('comments');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and not exists (select * from "comments" where "posts"."id" = "comments"."post_id")', $builder->toSql());
+    }
+
+    public function testDoesntHaveRelationWithinRelationJoinWithCustomBuilder()
+    {
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery()->joinRelation('posts', function($join) {
+            $join->doesntHave('comments');
+        });
+
+        $this->assertEquals('select * from "users" inner join "posts" on "posts"."user_id" = "users"."id" and not exists (select * from "comments" where "posts"."id" = "comments"."post_id")', $builder->toSql());
+        $this->assertEquals(CustomBuilder::class, get_class($builder));
     }
 }
 


### PR DESCRIPTION
We need to be able to do this:

```php
$query->joinRelation('my-first-relation', function($join) {
    $join->has('my-second-relation');
});
```