### PR TITLE
Fixed an error when using joinRelation on morphOne relationship with alias

### DIFF
--- a/src/RelationJoinQuery.php
+++ b/src/RelationJoinQuery.php
@@ -262,9 +262,9 @@ class RelationJoinQuery
     protected static function morphOneOrMany(Relation $relation, Builder $query, Builder $parentQuery, string $type = 'inner', string $alias = null)
     {
 		$qualifiedMorphType = $relation->getQualifiedMorphType();
-		if ( $alias ){
-			$arr = explode('.', $qualifiedMorphType);
-			$qualifiedMorphType = $alias . '.' . $arr[1];
+		if ($alias) {
+			[$table, $column] = explode('.', $qualifiedMorphType);
+			$qualifiedMorphType = $alias . '.' . $column;
 		}
 
         return static::hasOneOrMany($relation, $query, $parentQuery, $type, $alias)->where(

--- a/src/RelationJoinQuery.php
+++ b/src/RelationJoinQuery.php
@@ -261,8 +261,14 @@ class RelationJoinQuery
      */
     protected static function morphOneOrMany(Relation $relation, Builder $query, Builder $parentQuery, string $type = 'inner', string $alias = null)
     {
+		$qualifiedMorphType = $relation->getQualifiedMorphType();
+		if ( $alias ){
+			$arr = explode('.', $qualifiedMorphType);
+			$qualifiedMorphType = $alias . '.' . $arr[1];
+		}
+
         return static::hasOneOrMany($relation, $query, $parentQuery, $type, $alias)->where(
-            $relation->getQualifiedMorphType(), '=', $relation->getMorphClass()
+            $qualifiedMorphType, '=', $relation->getMorphClass()
         );
     }
 


### PR DESCRIPTION
```
$regexp = '/^((?<rel>[A-Za-z_]+)\/)?(?<col>[A-Za-z_]+)(\s+(?<sort_direction>[A-Za-z_]+))?$/';								
$matches = [];
preg_match($regexp, $orderby, $matches);

$relationship = array_key_exists('rel', $matches) ? $matches['rel'] : null;
$column = $matches['col'];
$sort_direction = array_key_exists('sort_direction', $matches) ? $matches['sort_direction'] : 'asc';

if ( $relationship ){
	$query->joinRelation($relationship . ' as ' . $relationship); //<-- The error happened here, when passing a morphOne relation name
	$column = $relationship . '.' . $column;
}

$query->orderBy($column, $sort_direction);
```