### PR TITLE
Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": ">=8.1",
-        "illuminate/contracts": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "illuminate/container": "^10.0|^11.0",
+        "illuminate/container": "^10.0|^11.0|^12.0",
         "larastan/larastan": "^2.9",
         "laravel/pint": "^1.5",
         "mockery/mockery": "^1.6.6",


### PR DESCRIPTION
Just putting this out there to get ahead of the curve on supporting Laravel 12 when it's released on 24th Feb 2025.

Apparently Laravel 12 will have zero breaking changes.