### PR TITLE
Usage `assert` breaks relation calls (v9)

### DIFF
--- a/tests/Unit/CustomBuilderTest.php
+++ b/tests/Unit/CustomBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\CustomBuilder;
 use Tests\Models\EloquentPostModelStub;
@@ -36,5 +37,19 @@ class CustomBuilderTest extends TestCase
         $builder = (new EloquentUserModelStub)->newQuery();
 
         $this->assertEquals(EloquentBuilder::class, get_class($builder));
+    }
+
+    #[Test]
+    public function can_call_join()
+    {
+        $this->connection->shouldIgnoreMissing();
+
+        $builder = (new EloquentPostModelStub)->newQuery();
+
+        $this->assertInstanceOf(Collection::class, $builder->leftJoinRelation('user')->get());
+
+        $builder = (new EloquentUserModelStub)->useCustomBuilder()->newQuery();
+
+        $this->assertInstanceOf(Collection::class, $builder->leftJoinRelation('posts')->get());
     }
 }


### PR DESCRIPTION
In commit db3ba2babe253075bffd913d747ed5e0539a7b6b there are several `assert` checks added, but they cause issues when calling relationships. I've added a testcase to show the failure. Do you want me to add a commit to this PR to revert remove the `assert` checks?